### PR TITLE
Support Mac and maybe Linux

### DIFF
--- a/Assets/Varneon/Blender FBX Importer/Editor/ImportWindow.cs
+++ b/Assets/Varneon/Blender FBX Importer/Editor/ImportWindow.cs
@@ -55,7 +55,7 @@ namespace Varneon.BlenderFBXImporter
             {
                 Path = path;
                 RelativePath = Path;
-                string appPath = Application.dataPath.Replace('/', '\\');
+                string appPath = Application.platform == RuntimePlatform.WindowsEditor ? Application.dataPath.Replace('/', '\\') : Application.dataPath;
                 RelativePath = RelativePath.Replace(appPath.Substring(0, appPath.IndexOf("Assets")), string.Empty);
                 Asset = AssetDatabase.LoadAssetAtPath(RelativePath, typeof(Object));
                 Content = new GUIContent(Path, AssetPreview.GetAssetPreview(Asset));


### PR DESCRIPTION
I haven't tested on Linux, which I don't have, but on Mac this gets the extension working. Specifically it:

* Avoids using backslashes in paths on non-Windows platforms
* Avoids the .exe extension on non-Windows platforms, where executables typically have no extension
* Adds special handling for Mac app bundles, which behind the scenes are directories that hold the actual executable and other resources
* Adds a default app path on Mac, since it's extremely likely for Blender to be installed in that location